### PR TITLE
Work In Progressの翻訳が壊れていたので修正

### DIFF
--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -766,12 +766,15 @@ translations:
     replace: '${setAPasswordOnYourAccountToPullOrPushVia}'
   - pattern: 'Commit message'
     replace: '${commitMessage}'
-  - pattern: 'Remove the <code>WIP</code> prefix from the title to allow this'
+  - pattern: 'This merge request is currently a Work In Progress'
+    replace: '${thisMergeRequestIsCurrentlyAWorkInProgress}'
+  - pattern: !!js/regexp /( +)When this merge request is ready,\n(.+)\n( +).+\n.+\n.+\n( +).+$/m
     replace: '${removeTheWIPPrefixFromTheTitleToAllowThis}'
-  - pattern: !!js/regexp /^( +)Remove the <code>WIP<\/code> prefix from the title to allow this\n( +)<strong>Work In Progress<\/strong> merge request to be merged when it's ready\.$/m
+    match-once: true
+  - pattern: !!js/regexp /^( +%a\.js-toggle-wip.+)\n( +)Remove the\n.+\n.+\n( +)to allow this\n.+\n.+$/m
     replace: '${removeTheWIPPrefix}'
     match-once: true
-  - pattern: !!js/regexp /^( +)Start the title with <code>\[WIP\]</code> or <code>WIP:</code> to prevent a\n( +)<strong>Work In Progress</strong> merge request from being merged before it's ready\.$/m
+  - pattern: !!js/regexp /^( +%a\.js-toggle-wip.+)\n( +)Start the title with\n.+\n( +)to prevent a\n.+\n.+$/m
     replace: '${startTheTitleWithWIP}'
     match-once: true
   - pattern: 'Share code pastes with others out of git repository'

--- a/config/ja.yml
+++ b/config/ja.yml
@@ -577,8 +577,10 @@ startGollumAndEditLocally: Gollumを開始してローカルで編集
 newWikiPage: 新しいWikiページ
 addAnSshKeyToYourProfileToPullOrPushViaSsh: 'SSHでプル/プッシュするためにはプロフィールにSSHキーを追加してください'
 setAPasswordOnYourAccountToPullOrPushVia: '{0}でプル/プッシュするにはパスワードを設定してください'
-removeTheWIPPrefix: "$1マージできる状態になったら <code>WIP</code> プレフィクスをタイトルから削除して\n$2<strong>Work In Progress (仕掛かり)</strong>のマージリクエストをマージできるようにします。"
-startTheTitleWithWIP: "$1タイトルを <code>[WIP]</code> または <code>WIP:</code> で開始すると\n$2<strong>Work In Progress (仕掛かり)</strong>のマージリクエストがマージできないようになります。"
+thisMergeRequestIsCurrentlyAWorkInProgress: 現在、このマージリクエストはWork In Progress (仕掛かり)です。
+removeTheWIPPrefixFromTheTitleToAllowThis: "$1マージできる状態になったら\n$2\n$3%code WIP:\n$3プレフィクスをタイトルから\n$3削除して\n$1マージリクエストをマージできるようにします。"
+removeTheWIPPrefix: "$3マージできる状態になったら\n$1\n$2%code WIP:\n$2プレフィクスをタイトルから\n$2削除して\n$3%strong Work In Progress (仕掛かり)\n$3のマージリクエストをマージできるようにします。"
+startTheTitleWithWIP: "$1\n$2%code WIP:\n$2でタイトルを開始すると\n$3%strong Work In Progress (仕掛かり)\n$3のマージリクエストが\n$3マージできないようになります。"
 shareCodekuninPastesWithOthersOutOfGitRepository: コードをGitリポジトリの外で共有しましょう。
 dontShowAgain: 次から表示しない
 visibilityLevel: 可視性レベル


### PR DESCRIPTION
GitLab 8.15.2でWork In Progressの翻訳が壊れていたので修正しました。
過去のバージョンとの互換性は無いのですが、どうすればよいでしょうか？